### PR TITLE
fix/release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       prereleaseTag: ${{ inputs.prereleaseTag }}
       build: false
+      node-version: "18"
     secrets:
       NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
     permissions:


### PR DESCRIPTION
Agrego node v.18 para instalar dependencias correctamente al querer buildear en el workflow de release (build+release)

Test: https://github.com/Parsimotion/endpoint-handler/actions/runs/17592063546